### PR TITLE
SAI TAM INT alternate proposal

### DIFF
--- a/inc/saiacl.h
+++ b/inc/saiacl.h
@@ -234,6 +234,18 @@ typedef enum _sai_acl_action_type_t
     /** Set isolation group to prevent traffic to members of isolation group */
     SAI_ACL_ACTION_TYPE_SET_ISOLATION_GROUP,
 
+    /** Set TAM INT group */
+    SAI_ACL_ACTION_TYPE_TAM_INT_GROUP,
+
+    /** Enable TAM INT drop reports */
+    SAI_ACL_ACTION_TYPE_TAM_INT_REPORT_DROPS,
+
+    /** Enable TAM INT tail drop reports */
+    SAI_ACL_ACTION_TYPE_TAM_INT_REPORT_TAIL_DROPS,
+
+    /** TAM INT should report all packets without filtering */
+    SAI_ACL_ACTION_TYPE_TAM_INT_REPORT_ALL_PACKETS,
+
 } sai_acl_action_type_t;
 
 /**
@@ -2159,9 +2171,46 @@ typedef enum _sai_acl_entry_attr_t
     SAI_ACL_ENTRY_ATTR_ACTION_SET_ISOLATION_GROUP,
 
     /**
+     * @brief TAM INT group ID
+     *
+     * @type sai_acl_action_data_t sai_object_id_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_TAM_INT_GROUP
+     * @default disabled
+     */
+    SAI_ACL_ENTRY_ATTR_ACTION_TAM_INT_GROUP,
+
+    /**
+     * @brief Enable TAM INT drop reports
+     *
+     * @type sai_acl_action_data_t bool
+     * @flags CREATE_AND_SET
+     * @default disabled
+     */
+    SAI_ACL_ENTRY_ATTR_ACTION_TAM_INT_REPORT_DROPS,
+
+    /**
+     * @brief Enable TAM INT tail drop reports
+     *
+     * @type sai_acl_action_data_t bool
+     * @flags CREATE_AND_SET
+     * @default disabled
+     */
+    SAI_ACL_ENTRY_ATTR_ACTION_TAM_INT_REPORT_TAIL_DROPS,
+
+    /**
+     * @brief TAM INT should report all packets without filtering
+     *
+     * @type sai_acl_action_data_t bool
+     * @flags CREATE_AND_SET
+     * @default disabled
+     */
+    SAI_ACL_ENTRY_ATTR_ACTION_TAM_INT_REPORT_ALL_PACKETS,
+
+    /**
      * @brief End of Rule Actions
      */
-    SAI_ACL_ENTRY_ATTR_ACTION_END = SAI_ACL_ENTRY_ATTR_ACTION_SET_ISOLATION_GROUP,
+    SAI_ACL_ENTRY_ATTR_ACTION_END = SAI_ACL_ENTRY_ATTR_ACTION_TAM_INT_REPORT_ALL_PACKETS,
 
     /**
      * @brief End of ACL Entry attributes

--- a/inc/saitam.h
+++ b/inc/saitam.h
@@ -412,6 +412,370 @@ typedef sai_status_t (*sai_set_tam_event_threshold_attribute_fn)(
         _In_ const sai_attribute_t *attr);
 
 /**
+ * @brief TAM INT types
+ */
+typedef enum _sai_tam_int_type_t
+{
+    /**
+     * @brief INT type IOAM
+     */
+    SAI_TAM_INT_TYPE_IOAM,
+
+    /**
+     * @brief INT type IFA1
+     */
+    SAI_TAM_INT_TYPE_IFA1,
+
+    /**
+     * @brief INT type IFA2
+     */
+    SAI_TAM_INT_TYPE_IFA2,
+
+    /**
+     * @brief INT type P4 INT v1
+     */
+    SAI_TAM_INT_TYPE_P4_INT_1,
+
+    /**
+     * @brief INT type P4 INT v2
+     */
+    SAI_TAM_INT_TYPE_P4_INT_2,
+
+    /**
+     * @brief INT type hop-by-hop reports
+     */
+    SAI_TAM_INT_TYPE_HOP_BY_HOP_REPORTS,
+
+    /**
+     * @brief INT type vendor extension
+     */
+    SAI_TAM_INT_TYPE_EXTN
+
+} sai_tam_int_type_t;
+
+/**
+ * @brief Attributes for TAM INT Group
+ */
+typedef enum _sai_tam_int_group_attr_t
+{
+
+    /**
+     * @brief Start of Attributes
+     */
+    SAI_TAM_INT_GROUP_ATTR_START,
+
+    /**
+     * @brief Type of INT method
+     *
+     * @type sai_tam_int_type_t
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     */
+    SAI_TAM_INT_GROUP_ATTR_TYPE = SAI_TAM_INT_GROUP_ATTR_START,
+
+    /**
+     * @brief IOAM trace type
+     *
+     * @type sai_uint32_t
+     * @flags CREATE_AND_SET
+     * @condition SAI_TAM_INT_GROUP_ATTR_TYPE == SAI_TAM_INT_TYPE_IOAM
+     */
+    SAI_TAM_INT_GROUP_ATTR_IOAM_TRACE_TYPE,
+
+    /**
+     * @brief Inline or Clone mode
+     * Inline mode will insert header and metadata in live packet
+     * Clone mode will insert header and metadata in cloned packet
+     *
+     * @type bool
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     */
+    SAI_TAM_INT_GROUP_ATTR_INLINE,
+
+    /**
+     * @brief Trace vector value
+     * trace vector is used to specified the fields
+     * of interest in metadata header
+     *
+     * @type sai_uint16_t
+     * @flags CREATE_AND_SET
+     * @condition SAI_TAM_INT_GROUP_ATTR_TYPE == SAI_TAM_INT_TYPE_IFA1 or SAI_TAM_INT_TYPE_IFA2
+     * @default 0
+     */
+    SAI_TAM_INT_GROUP_ATTR_IFA_TRACE_VECTOR,
+
+    /**
+     * @brief Action vector value
+     * action vector is used to specified the actions
+     * of interest on metadata header
+     * value of 0 means no actions of interest
+     *
+     * @type sai_uint16_t
+     * @flags CREATE_AND_SET
+     * @condition SAI_TAM_INT_GROUP_ATTR_TYPE == SAI_TAM_INT_TYPE_IFA1 or SAI_TAM_INT_TYPE_IFA2
+     * @default 0
+     */
+    SAI_TAM_INT_GROUP_ATTR_IFA_ACTION_VECTOR,
+
+    /**
+     * @brief P4 INT instruction bitmap
+     *
+     * @type sai_uint16_t
+     * @flags CREATE_AND_SET
+     * @condition SAI_TAM_INT_GROUP_ATTR_TYPE == SAI_TAM_INT_TYPE_P4_INT_1 or SAI_TAM_INT_TYPE_P4_INT_2
+     */
+    SAI_TAM_INT_GROUP_ATTR_P4_INT_INSTRUCTION_BITMAP,
+
+    /**
+     * @brief Maximum number of hope allowed in the path
+     *
+     * @type sai_uint8_t
+     * @flags CREATE_AND_SET
+     * @default 0
+     */
+    SAI_TAM_INT_GROUP_ATTR_MAX_HOP_COUNT,
+
+    /**
+     * @brief Maximum length of metadata stack, always word aligned
+     *
+     * @type sai_uint8_t
+     * @flags CREATE_AND_SET
+     * @default 0
+     */
+    SAI_TAM_INT_GROUP_ATTR_MAX_LENGTH,
+
+    /**
+     * @brief Metadata name space ID
+     * name space id defines the applicable format of metadata header
+     *
+     * @type sai_uint8_t
+     * @flags CREATE_AND_SET
+     * @default 0
+     */
+    SAI_TAM_INT_GROUP_ATTR_NAME_SPACE_ID,
+
+    /**
+     * @brief Metadata name space ID scope
+     * name space id scope is global or local
+     *
+     * @type bool
+     * @flags CREATE_AND_SET
+     * @default false
+     */
+    SAI_TAM_INT_GROUP_ATTR_NAME_SPACE_ID_GLOBAL,
+
+    /**
+     * @brief End of Attributes
+     */
+    SAI_TAM_INT_GROUP_ATTR_END,
+
+    /** Custom range base value */
+    SAI_TAM_INT_GROUP_ATTR_CUSTOM_RANGE_START = 0x10000000,
+
+    /** End of custom range base */
+    SAI_TAM_INT_GROUP_ATTR_CUSTOM_RANGE_END
+
+} sai_tam_int_group_attr_t;
+
+/**
+ * @brief Create and return a INT group object
+ *
+ * @param[out] tam_int_group_id INT object
+ * @param[in] switch_id Switch object id
+ * @param[in] attr_count Number of attributes
+ * @param[in] attr_list Array of attributes
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_create_tam_int_group_fn)(
+        _Out_ sai_object_id_t *tam_int_group_id,
+        _In_ sai_object_id_t switch_id,
+        _In_ uint32_t attr_count,
+        _In_ const sai_attribute_t *attr_list);
+
+/**
+ * @brief Deletes a specified INT group object
+ *
+ * @param[in] tam_int_group_id INT group object id
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_remove_tam_int_group_fn)(
+        _In_ sai_object_id_t tam_int_group_id);
+
+/**
+ * @brief Get values for specified INT group object attributes
+ *
+ * @param[in] tam_int_group_id INT group object id
+ * @param[in] attr_count Number of attributes
+ * @param[inout] attr_list Array of attributes
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_get_tam_int_group_attribute_fn)(
+        _In_ sai_object_id_t tam_int_group_id,
+        _In_ uint32_t attr_count,
+        _Inout_ sai_attribute_t *attr_list);
+
+/**
+ * @brief Set value for a specified INT group_object attribute
+ *
+ * @param[in] tam_int_group_id INT group object id
+ * @param[in] attr Attribute
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_set_tam_int_group_attribute_fn)(
+        _In_ sai_object_id_t tam_int_group_id,
+        _In_ const sai_attribute_t *attr);
+
+/**
+ * @brief Attributes for TAM INT
+ */
+typedef enum _sai_tam_int_attr_t
+{
+
+    /**
+     * @brief Start of Attributes
+     */
+    SAI_TAM_INT_ATTR_START,
+
+    /**
+     * @brief Globally unique switch ID
+     *
+     * @type sai_uint32_t
+     * @flags CREATE_AND_SET
+     * @default 0
+     */
+    SAI_TAM_INT_SWITCH_ID = SAI_TAM_INT_ATTR_START,
+
+    /**
+     * @brief Probe Marker 1
+     *
+     * @type sai_uint32_t
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     */
+    SAI_TAM_INT_ATTR_PB1,
+
+    /**
+     * @brief Probe Marker 2
+     *
+     * @type sai_uint32_t
+     * @flags MANDATORY_ON_CREATE | CREATE_ONLY
+     */
+    SAI_TAM_INT_ATTR_PB2,
+
+    /**
+     * @brief Protocol value used for INT
+     *
+     * @type sai_uint8_t
+     * @flags CREATE_AND_SET
+     * @default 0
+     */
+    SAI_TAM_INT_ATTR_L3_PROTO,
+
+    /**
+     * @brief DSCP value used to indicate presence of INT
+     *
+     * @type sai_uint8_t
+     * @flags CREATE_AND_SET
+     * @default disabled
+     */
+    SAI_TAM_INT_ATTR_INT_DSCP,
+
+    /**
+     * @brief Specifies the ports at the edge of the TAM INT domain
+     *
+     * @type sai_object_list_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_PORT
+     * @default empty
+     */
+    SAI_TAM_INT_ATTR_EDGE_PORT_LIST,
+
+    /**
+     * @brief TAM INT flow liveness period in seconds
+     *
+     * @type sai_uint16_t
+     * @flags CREATE_AND_SET
+     * @default 0
+     */
+    SAI_TAM_INT_ATTR_FLOW_LIVENESS_PERIOD,
+
+    /**
+     * @brief Latency sensitivity for flow state change detection
+     *
+     * @type sai_uint8_t
+     * @flags CREATE_AND_SET
+     * @default 0
+     */
+    SAI_TAM_INT_ATTR_LATENCY_SENSITIVITY,
+
+    /**
+     * @brief End of Attributes
+     */
+    SAI_TAM_INT_ATTR_END,
+
+    /** Custom range base value */
+    SAI_TAM_INT_ATTR_CUSTOM_RANGE_START = 0x10000000,
+
+    /** End of custom range base */
+    SAI_TAM_INT_ATTR_CUSTOM_RANGE_END
+
+} sai_tam_int_attr_t;
+
+/**
+ * @brief Create and return a INT object
+ *
+ * @param[out] tam_int_id INT object
+ * @param[in] switch_id Switch object id
+ * @param[in] attr_count Number of attributes
+ * @param[in] attr_list Array of attributes
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_create_tam_int_fn)(
+        _Out_ sai_object_id_t *tam_int_id,
+        _In_ sai_object_id_t switch_id,
+        _In_ uint32_t attr_count,
+        _In_ const sai_attribute_t *attr_list);
+
+/**
+ * @brief Deletes a specified INT object
+ *
+ * @param[in] tam_int_id INT object id
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_remove_tam_int_fn)(
+        _In_ sai_object_id_t tam_int_id);
+
+/**
+ * @brief Get values for specified INT object attributes
+ *
+ * @param[in] tam_int_id INT object id
+ * @param[in] attr_count Number of attributes
+ * @param[inout] attr_list Array of attributes
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_get_tam_int_attribute_fn)(
+        _In_ sai_object_id_t tam_int_id,
+        _In_ uint32_t attr_count,
+        _Inout_ sai_attribute_t *attr_list);
+
+/**
+ * @brief Set value for a specified INT object attribute
+ *
+ * @param[in] tam_int_id INT object id
+ * @param[in] attr Attribute
+ *
+ * @return #SAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef sai_status_t (*sai_set_tam_int_attribute_fn)(
+        _In_ sai_object_id_t tam_int_id,
+        _In_ const sai_attribute_t *attr);
+
+/**
  * @brief TAM telemetry types supported
  */
 typedef enum _sai_tam_telemetry_type_t
@@ -1602,6 +1966,16 @@ typedef struct _sai_tam_api_t
     sai_remove_tam_event_threshold_fn         remove_tam_event_threshold;
     sai_set_tam_event_threshold_attribute_fn  set_tam_event_threshold_attribute;
     sai_get_tam_event_threshold_attribute_fn  get_tam_event_threshold_attribute;
+
+    sai_create_tam_int_fn                     create_tam_int;
+    sai_remove_tam_int_fn                     remove_tam_int;
+    sai_set_tam_int_attribute_fn              set_tam_int_attribute;
+    sai_get_tam_int_attribute_fn              get_tam_int_attribute;
+
+    sai_create_tam_int_group_fn               create_tam_int_group;
+    sai_remove_tam_int_group_fn               remove_tam_int_group;
+    sai_set_tam_int_group_attribute_fn        set_tam_int_group_attribute;
+    sai_get_tam_int_group_attribute_fn        get_tam_int_group_attribute;
 
     sai_create_tam_tel_type_fn                create_tam_tel_type;
     sai_remove_tam_tel_type_fn                remove_tam_tel_type;

--- a/inc/saitypes.h
+++ b/inc/saitypes.h
@@ -257,7 +257,9 @@ typedef enum _sai_object_type_t
     SAI_OBJECT_TYPE_TAM_COLLECTOR            = 78,
     SAI_OBJECT_TYPE_TAM_EVENT_ACTION         = 79,
     SAI_OBJECT_TYPE_TAM_EVENT                = 80,
-    SAI_OBJECT_TYPE_MAX                      = 81,
+    SAI_OBJECT_TYPE_TAM_INT_GROUP            = 81,
+    SAI_OBJECT_TYPE_TAM_INT                  = 82,
+    SAI_OBJECT_TYPE_MAX                      = 83,
 } sai_object_type_t;
 
 typedef struct _sai_u8_list_t

--- a/meta/acronyms.txt
+++ b/meta/acronyms.txt
@@ -43,6 +43,7 @@ IFA - Inband Flow Analyzer
 IFA1 - Inband Flow Analyzer version 1
 IFA2 - Inband Flow Analyzer version 2
 IGMP - Internet Group Management Protocol
+INT - In-band Network Telemetry
 IOAM - In-situ Operations And Management
 IP - Internet Protocol
 IPFIX - IP Flow Information Export


### PR DESCRIPTION
Differences from the previous SAI TAM INT proposal:

1. Flow selection

   The previous SAI TAM INT proposal introduces a new TAM INT flow object
   which is essentially a lightweight ACL entry. This specifies match
   attributes such as source IP address with mask, dest IP address with
   mask, protocol (no mask), source port (no mask or range), dest port
   (no mask or range), VNID (no mask), and inner header fields (no mask,
   even on source or dest IP address). Besides being redundant with the
   ACL rule match fields, this has a bigger problem with respect to
   overlaps and conflicts. Each SAI TAM INT object specifies a list of
   TAM INT flow objects. There may be multiple such SAI TAM INT objects.

   What happens when there are overlapping TAM INT flow objects, each
   referred to from a different SAI TAM INT object that specifies
   different actions (e.g. IOAM trace type value or trace vector or
   action vector)?
   Which TAM INT flow object wins?

   Rather than introduce a TAM specific lightweight ACL entry, this commit
   proposes to use ACLs directly. The ACL actions should be directly
   extended to incorporate whatever is needed for the TAM INT functionality.
   This allows users to access the full power of ACLs including prioritized
   ordering of rules, field masking, interspersing rules with no action to
   simplify configuration, etc. An indirection through a TAM INT Group
   object is used to group together various attributes such as IOAM trace
   type, IFA trace vector, max hop count, max length, namespace ID, etc,
   reducing the complexity of the ACL extensions that support TAM INT.

   This approach removes several redundant objects and attributes such as
   the TAM INT flow object, counter object (because ACL rules can specify
   counters), and sample attribute (because ACL entries can directly refer
   to sample objects).

   This approach is similar to how mirroring of a subset of traffic is
   supported. Rather than introduce a flow object with regard to mirroring,
   SAI ACL was simply extended to support ingress and egress mirroring as
   ACL actions. The same thing can easily apply for SAI TAM INT.

2. TAM INT domain boundaries and INT termination

   The previous SAI TAM INT proposal provisions roles of INT initiator,
   INT transit, and INT terminator through a node type attribute in the
   TAM INT object. For example, a port refers to a TAM object which has
   at least one TAM INT object with a node type with value terminator.

   There are two issues with such an approach. One is that the proposed
   TAM INT object serves multiple purposes, including specification of
   trace vectors, flow lists, etc. Due to this, one TAM object bound
   referred to by a port may have many TAM INT objects for different
   flows, different trace vectors, etc. Since the granularity is different,
   these things do not really belong in the same object.

   The second issue is that there is no need to separate specification of
   initiator, transit, and terminator functions. It is simpler to just
   specify the edge of the domain, which clearly indicates that outgoing
   packets with INT should terminate INT. Initiation of packets with INT
   would be subject to ACL configuration as proposed in #1 above.

3. The TAM INT object also specifies the binding between TAM INT and
   the TAM collector and report objects.

   Upon termination of INT, it is not necessary for every packet to
   trigger a report. Receipt of such a packet should feed through event
   detection logic that determines whether to generate a report.

   This proposes to reuse the already existing TAM event object, treating
   receipt of packets with INT as events. The TAM event object already
   specifies reporting of events, referring to the TAM collector and
   report objects that apply whenever such an event occurs.

4. This proposes a single TAM INT object that specifies attributes such
   as INT switch ID, edge port list, and transport specific values that
   identify presence of INT in a packet. For the latter, the thought is
   that this does not need to be specified with every ACL action, it can
   just be specified once and applied to all.