### PR TITLE
nat_type in sai_nat_entry_t

### DIFF
--- a/inc/sainat.h
+++ b/inc/sainat.h
@@ -326,7 +326,12 @@ typedef struct _sai_nat_entry_t
      * @objects SAI_OBJECT_TYPE_VIRTUAL_ROUTER
      */
     sai_object_id_t vr_id;
-
+    
+    /**
+     * @brief NAT entry type
+     */
+    sai_nat_type_t nat_type;
+    
     /**
      * @brief NAT entry data
      */


### PR DESCRIPTION
nat_type field is added in sai_nat_entry_t to differentiate nat entry from SAI_NAT_TYPE_DESTINATION_NAT_POOL and SAI_NAT_TYPE_DESTINATION_NAT