### PR TITLE
ECMP Member Configuration Support

### DIFF
--- a/inc/saiswitch.h
+++ b/inc/saiswitch.h
@@ -2696,6 +2696,23 @@ typedef enum _sai_switch_attr_t
     SAI_SWITCH_ATTR_IPSEC_SA_STATUS_CHANGE_NOTIFY,
 
     /**
+     * @brief Number of ECMP members supported by My MAC entries installed on the switch
+     *
+     * @type sai_uint32_t
+     * @flags READ_ONLY
+     */
+    SAI_SWITCH_ATTR_MAX_ECMP_MEMBER_COUNT,
+
+    /**
+     * @brief Number of  ECMP Members configured on the switch
+     *
+     * @type sai_uint32_t
+     * @flags CREATE_AND_SET
+     * @default 64
+     */
+    SAI_SWITCH_ATTR_ECMP_MEMBER_COUNT,
+
+    /**
      * @brief End of attributes
      */
     SAI_SWITCH_ATTR_END,


### PR DESCRIPTION
Two new Switch attributes are introduced.
Read Only:
SAI_SWITCH_ATTR_MAX_ECMP_MEMBER_COUNT
This attribute is queried during switch init to find out device specific max number of ecmp members supported.

CREATE_AND_SET (read/write):
SAI_SWITCH_ATTR_ECMP_MEMBER_COUNT
This attribute is set based on the query for MAX_ECMP_MEMBER_COUNT and can be changed dynamically.
If the SAI adapter doesn't support dynamic change of this attribute based on certain conditions like if ECMP groups are already configured then MUST return error.

Typical Workflow:
1. Switch object create 
2. Switch get SAI_SWITCH_ATTR_MAX_ECMP_MEMBER_COUNT: say SAI adapter returns 2k
3. Switch set SAI_SWITCH_ATTR_ECMP_MEMBER_COUNT
4. If step 3 is invoked after the system is fully configured and forwarding traffic
    - SAI adapter MAY return error if HW is not capable of dynamically adjusting the ECMP group size